### PR TITLE
Dataloader bugfix

### DIFF
--- a/GenNet_utils/Dataloader.py
+++ b/GenNet_utils/Dataloader.py
@@ -185,7 +185,7 @@ class EvalGenerator(K.utils.Sequence):
         return val_len
 
     def __getitem__(self, idx):
-        if len(glob.glob(self.genotype_path + '*.h5')) > 0:
+        if self.multi_h5:
             xbatch, ybatch = self.multi_genotype_matrix(idx)
         else:
             xbatch, ybatch = self.single_genotype_matrix(idx)
@@ -197,7 +197,7 @@ class EvalGenerator(K.utils.Sequence):
         ybatch = self.eval_subjects["labels"].iloc[idx * self.batch_size:((idx + 1) * self.batch_size)]
         xbatchid = np.array(self.eval_subjects["genotype_row"].iloc[idx * self.batch_size:((idx + 1) * self.batch_size)],
                             dtype=np.int64)
-        xbatch = genotype_hdf[0].root.data[xbatchid, :]
+        xbatch = genotype_hdf.root.data[xbatchid, :]
         ybatch = np.reshape(np.array(ybatch), (-1, 1))
         genotype_hdf.close()
         return xbatch, ybatch


### PR DESCRIPTION
The function single_genotype_matrix contained calls to two non-existing functions to open and close the genotype file. I deleted the function calls and added code to open and close the genotype file.
Additionally, in EvalGenerator the if statement in __getitem__ evaluated the wrong statement, causing the generator to use multi_genotype_matrix() in the presence of >= 1 genotype file, instead of >1 genotype file.