### PR TITLE
Add -hidden_activation argument for configurable hidden-layer activation

### DIFF
--- a/GenNet.py
+++ b/GenNet.py
@@ -257,7 +257,11 @@ class ArgumentParser():
             action='store_true',
             default=False,
             help='Use the pervariantnorm layer instead of batchnorm for better normalization for interpretation')
-            
+        parser_train.add_argument(
+            "-hidden_activation",
+            default=None, type=str,
+            help="Activation function for hidden layers. Overrides default: tanh for classification, relu for regression")
+
         return parser_train
 
     def make_parser_plot(self, parser_plot):

--- a/GenNet_utils/Create_network.py
+++ b/GenNet_utils/Create_network.py
@@ -55,11 +55,13 @@ def regression_properties(datapath):
     return mean_ytrain, negative_values_ytrain
 
 
-def layer_block(model, mask, i, regression, L1_act=0.01,  batchnorm=True):
-    if regression:
-        activation_type="relu"
+def layer_block(model, mask, i, regression, L1_act=0.01, batchnorm=True, hidden_activation=None):
+    if hidden_activation is not None:
+        activation_type = hidden_activation
+    elif regression:
+        activation_type = "relu"
     else:
-        activation_type="tanh"
+        activation_type = "tanh"
     
     model = LocallyDirected1D(mask=mask, filters=1, input_shape=(mask.shape[0], 1),
                               name="LocallyDirected_" + str(i), activity_regularizer=K.regularizers.l1(L1_act))(model)
@@ -122,7 +124,8 @@ def create_network_from_npz(datapath,
                             one_hot = False,
                             num_covariates=0,
                             mask_order = [],
-                            batchnorm = True):
+                            batchnorm = True,
+                            hidden_activation=None):
     print("Creating networks from npz masks")
     print("regression", regression)
     print("one_hot", one_hot)
@@ -187,7 +190,7 @@ def create_network_from_npz(datapath,
 
     for i in range(len(masks)):
         mask = masks[i]
-        model = layer_block(model, mask, i, regression, L1_act=L1_act, batchnorm=True)
+        model = layer_block(model, mask, i, regression, L1_act=L1_act, batchnorm=True, hidden_activation=hidden_activation)
 
     model = K.layers.Flatten()(model)
 
@@ -212,15 +215,16 @@ def create_network_from_npz(datapath,
 
 
 
-def create_network_from_csv(datapath, 
-                            inputsize, 
+def create_network_from_csv(datapath,
+                            inputsize,
                             genotype_path,
-                            l1_value=0.01, 
-                            L1_act =0.01, 
+                            l1_value=0.01,
+                            L1_act =0.01,
                             regression=False,
                             one_hot=False,
                             num_covariates=0,
-                            batchnorm=True):
+                            batchnorm=True,
+                            hidden_activation=None):
     
     print("Creating networks from npz masks")
     print("regression", regression)
@@ -258,7 +262,7 @@ def create_network_from_csv(datapath,
             matrixshape = (network_csv[columns[i]].max() + 1, network_csv[columns[i + 1]].max() + 1)
         mask = scipy.sparse.coo_matrix(((matrix_ones), matrix_coord), shape = matrixshape)
         masks.append(mask)
-        model = layer_block(model, mask, i, regression, L1_act=L1_act, batchnorm=batchnorm)
+        model = layer_block(model, mask, i, regression, L1_act=L1_act, batchnorm=batchnorm, hidden_activation=hidden_activation)
 
     model = K.layers.Flatten()(model)
 

--- a/GenNet_utils/Train_network.py
+++ b/GenNet_utils/Train_network.py
@@ -254,7 +254,8 @@ def get_network(args):
     args.improved_norm = args.improved_norm if hasattr(args, 'improved_norm') else False
     args.L1 = args.L1 if hasattr(args, 'L1') else 0
     args.L1_act = args.L1_act if hasattr(args, 'L1_act') else 0
-    
+    args.hidden_activation = args.hidden_activation if hasattr(args, 'hidden_activation') else None
+
     batchnorm = not(args.improved_norm)
 
     global weight_positive_class, weight_negative_class
@@ -291,18 +292,18 @@ def get_network(args):
                                                      filters=args.filters, one_hot=args.onehot)
     else:
         if os.path.exists(args.datapath + "/topology.csv"):
-            model, masks = create_network_from_csv(datapath=args.datapath, inputsize=args.inputsize, 
+            model, masks = create_network_from_csv(datapath=args.datapath, inputsize=args.inputsize,
                                                    genotype_path=args.genotype_path,
                                                    l1_value=args.L1, L1_act=args.L1_act, regression=regression,
                                                    num_covariates=args.num_covariates, one_hot=args.onehot,
-                                                   batchnorm=batchnorm )
+                                                   batchnorm=batchnorm, hidden_activation=args.hidden_activation)
         elif len(glob.glob(args.datapath + "/*.npz")) > 0:
-            model, masks = create_network_from_npz(datapath=args.datapath, inputsize=args.inputsize, 
+            model, masks = create_network_from_npz(datapath=args.datapath, inputsize=args.inputsize,
                                                    genotype_path=args.genotype_path,
                                                    l1_value=args.L1, L1_act=args.L1_act, regression=regression,
                                                    num_covariates=args.num_covariates, one_hot=args.onehot,
                                                    mask_order=args.mask_order if hasattr(args, 'mask_order') else None,
-                                                   batchnorm=batchnorm)
+                                                   batchnorm=batchnorm, hidden_activation=args.hidden_activation)
 
     optimizer_model = Adam(lr=args.learning_rate)
 


### PR DESCRIPTION
## Summary
Adds an optional `-hidden_activation` argument to `GenNet.py train` that lets the user override the activation function used in the hidden layers. When ommitted, original behaviour is preserved: tanh for classification, relu for regression

## Motivation
Making it configurable is useful for methodological comparisons, e.g. studying how the activation choice affects feature importance / interpretability and the stability of feature rankings.

## Behaviour
- When `-hidden_activation` is omitted, behaviour is unchanged: `tanh` for classification, `relu` for regression.
- When provided, the value is passed directly to `keras.layers.Activation`, so any valid Keras activation string works (e.g. `relu`, `tanh`, `sigmoid`, etc.).

### Example
python GenNet.py train -path ./data -out ./results -ID 1 -problem_type classification -hidden_activation relu

Add -hidden_activation argument for configurable hidden layer activation. Allow user to override the default activation function for hidden layers via -hidden_activation <keras activation string>. When ommitted, original behaviour is preserved: tanh for classification, relu for regression