### PR TITLE
Lower ReduceLROnPlateau from 0.001 to 1e-6

### DIFF
--- a/GenNet_utils/Train_network.py
+++ b/GenNet_utils/Train_network.py
@@ -88,7 +88,7 @@ def train_model(args):
                                                   verbose=1, save_best_only=True, mode='auto')
 
     reduce_lr = K.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.2,
-                                              patience=5, min_lr=1e-7)
+                                              patience=5, min_lr=1e-6)
 
     if os.path.exists(args.resultpath + '/bestweights_job.h5') and not(args.resume):
         print('Model already Trained')

--- a/GenNet_utils/Train_network.py
+++ b/GenNet_utils/Train_network.py
@@ -88,7 +88,7 @@ def train_model(args):
                                                   verbose=1, save_best_only=True, mode='auto')
 
     reduce_lr = K.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.2,
-                                              patience=5, min_lr=0.001)
+                                              patience=5, min_lr=1e-7)
 
     if os.path.exists(args.resultpath + '/bestweights_job.h5') and not(args.resume):
         print('Model already Trained')


### PR DESCRIPTION
## Summary
Lowers the `min_lr` floor of the `ReduceLROnPlateau` callback in `train_model` from `0.001` to `1e-6`.

## Motivation
`ReduceLROnPlateau` is configured with `factor=0.2` and `min_lr=0.001`. Because the floor (min_lr = 0.001) is close to typical starting learning rates, the scheduler has little or no room to anneal the learning rate. 
Lowering the floor to `1e-6` lets the learning rate decay accross several reductions when `val_loss` plateaus, which help convergence.