### PR TITLE
Fix DeepExplainer crash: pass background data to shap.DeepExplainer

### DIFF
--- a/GenNet_utils/Interpret.py
+++ b/GenNet_utils/Interpret.py
@@ -86,7 +86,7 @@ def get_DeepExplainer_scores(args):
     xval = xval if args.regression else xval[yval==0,:]
     xtest = xtest if args.regression else xtest[ytest==1,:]
     
-    explainer  = shap.DeepExplainer((model.input, model.output), )
+    explainer  = shap.DeepExplainer((model.input, model.output), xval)
     print("Created explainer")
 
     if os.path.exists( args.resultpath+ "/DeepExplain_test.npy"):


### PR DESCRIPTION
## Summary
`get_DeepExplainer_scores` in `GenNet_utils/Interpret.py` crashes because `shap.DeepExplainer` is called without its required background `data` argument, so `interpret -type DeepExplain` never runs.

## Bug
`explainer = shap.DeepExplainer((model.input, model.output))`
shap.DeepExplainer(model, data) requires background data as its second argument, so every run fails with:
TypeError: Deep.__init__() missing 1 required positional argument: 'data'

## Fix
Pass the computed xval as the background.
`explainer = shap.DeepExplainer((model.input, model.output), xval)`