### PR TITLE
 Fix double sigmoid in `remove_batchnorm_model` when dropping covariates

### DIFF
--- a/GenNet_utils/Create_network.py
+++ b/GenNet_utils/Create_network.py
@@ -535,7 +535,8 @@ def remove_batchnorm_model(model, masks, keep_cov = False):
         return model
     
             
-    for layer in original_model.layers[1:]: 
+    cov_removed = False
+    for layer in original_model.layers[1:]:
         # Skip BatchNormalization layers
         if not isinstance(layer, tf.keras.layers.BatchNormalization):
             # Handle LocallyDirected1D layer with custom arguments
@@ -547,7 +548,9 @@ def remove_batchnorm_model(model, masks, keep_cov = False):
                 x = new_layer(x)
                 mask_num = mask_num + 1
             elif "_cov" in layer.name and not keep_cov:
-                pass
+                cov_removed = True
+            elif cov_removed and isinstance(layer, tf.keras.layers.Activation):
+                pass  # drop the cov head's trailing activation -> avoids double sigmoid
             else:
                 # Add other layers as they are
                 x = layer.__class__.from_config(layer.get_config())(x)


### PR DESCRIPTION
**File changed:** `GenNet_utils/Create_network.py`

## Summary

When `remove_batchnorm_model(..., keep_cov=False)` strips the covariate head, it re attaches the covariate branch's final activation on top of the phenotype branch's activation, producing two stacked sigmoids. This keeps the prediction
ranking but rescales SHAP values by an almost constant factor. The fix drops that trailing activation.

## Architecture

The classification model has a two stage output head:

```
flatten
  → output_layer (Dense)        phenotype logit
  → activation_2 (sigmoid)      phenotype score
  → concatenate_cov (+ 7 covariates)
  → batchnorm_cov
  → output_layer_cov (Dense)    covariate adjusted logit
  → activation_3 (sigmoid)      final prediction
```

Two sigmoids are correct here: one for the genotype score, one for the covariate adjusted output.

## The bug

The function rebuilds the model and skips the covariate head by matching `"_cov"` in the layer name. `concatenate_cov`, `batchnorm_cov` and `output_layer_cov` are skipped correctly, but the final sigmoid `activation_3` is not named with `_cov`,
so it fell into the generic `else` branch and was re added on top of `activation_2`. The decoupled phenotype output became `sigmoid(sigmoid(logit))` instead of a single sigmoid. The extra sigmoid saturates the output and multiplies every SHAP attribution by roughly a constant.

## The fix

Track when the covariate head has been removed and drop the activation that follows it:

```python
elif "_cov" in layer.name and not keep_cov:
    cov_removed = True
elif cov_removed and isinstance(layer, tf.keras.layers.Activation):
    pass  # drop the cov head's trailing activation, avoids double sigmoid
```

## Effect on SHAP values

Tried on a small set of 300 samples (DeepExplainer over the 38,225 input nodes), before vs after the fix on the same trained weights.

Top genes keep their order while the values shift:

```
Rank  Gene      before      after
1     NOD2      9.13e-06    3.88e-05
2     NOD2      6.92e-06    2.94e-05
3     IL7       6.80e-06    2.89e-05
4     IL7       5.58e-06    2.37e-05
5     CDKAL1    4.81e-06    2.04e-05
6     IL12RB2   4.70e-06    1.99e-05
7     IL23R     4.67e-06    1.99e-05
```

## Why it matters

Ranking only analyses are unaffected. Anything that uses the raw values, such as thresholds or a product like `weight(i,j) * SHAP_interaction(i,j)`, was down weighting SHAP.
