### PR TITLE
Fix double sigmoid in remove_cov

### DIFF
--- a/GenNet_utils/Create_network.py
+++ b/GenNet_utils/Create_network.py
@@ -574,18 +574,19 @@ def remove_cov(model, masks):
     x = inputs
 
     mask_num = 0
-    for layer in original_model.layers[1:]: 
+    cov_removed = False
+    for layer in original_model.layers[1:]:
         # Skip BatchNormalization layers
         if isinstance(layer, LocallyDirected1D):
             config = layer.get_config()
-            new_layer = LocallyDirected1D(filters=config['filters'], 
+            new_layer = LocallyDirected1D(filters=config['filters'],
                                             mask=masks[mask_num],
                                             name=config['name'])
             x = new_layer(x)
             mask_num = mask_num + 1
         elif "_cov" in layer.name:
-            pass
-        else:
+            cov_removed = True
+        elif not cov_removed:
             # Add other layers as they are
             x = layer.__class__.from_config(layer.get_config())(x)
 


### PR DESCRIPTION
**Fix double sigmoid in remove_cov** (same issue as remove_batchnorm_model fix)
**File Changed*:* GenNet_utils/Create_network.py

## Summary
`remove_cov` has the same double-sigmoid bug as that just fixed in `remove_batchnorm_model`. When it strips the coviarate head by matching "_cov" in the layer name, the head's trailing sigmoid (activation_3) is not named with _cov, so it falls into the generic else branch and get re-added on top of the phenotype branch's activation_2. 
The decoupled phenotype output becomes sigmoid(sigmoid(logit)) instead of a single sigmoid.

As before, this preserves the prediction ranking but rescales every value.

## The fix
Track when the coviarate head has been removed and stop re-adding the layers that follow it, so the trailing activation function is dropped and the output keeps a single sigmoid.